### PR TITLE
Updated searchFunc map generics

### DIFF
--- a/findX.java
+++ b/findX.java
@@ -3,51 +3,52 @@ import static java.util.Map.entry;
 
 public class findX
 {
-    private static Map<String, String> letToNumMap = Map.ofEntries
+    private static Map<String, Integer> letToNumMap = Map.ofEntries
         (
-            entry("a", "1"),
-            entry("b", "2"),
-            entry("c", "3"),
-            entry("d", "4"),
-            entry("e", "5"),
-            entry("f", "6"),
-            entry("g", "7"),
-            entry("h", "8"),
-            entry("i", "9"),
-            entry("j", "10"),
-            entry("k", "11"),
-            entry("l", "12"),
-            entry("m", "13"),
-            entry("n", "14"),
-            entry("o", "15"),
-            entry("p", "16"),
-            entry("q", "17"),
-            entry("r", "18"),
-            entry("s", "19"),
-            entry("t", "20"),
-            entry("u", "21"),
-            entry("v", "22"),
-            entry("w", "23"),
-            entry("x", "24"),
-            entry("y", "25"),
-            entry("z", "26")
+            entry("a", 1),
+            entry("b", 2),
+            entry("c", 3),
+            entry("d", 4),
+            entry("e", 5),
+            entry("f", 6),
+            entry("g", 7),
+            entry("h", 8),
+            entry("i", 9),
+            entry("j", 10),
+            entry("k", 11),
+            entry("l", 12),
+            entry("m", 13),
+            entry("n", 14),
+            entry("o", 15),
+            entry("p", 16),
+            entry("q", 17),
+            entry("r", 18),
+            entry("s", 19),
+            entry("t", 20),
+            entry("u", 21),
+            entry("v", 22),
+            entry("w", 23),
+            entry("x", 24),
+            entry("y", 25),
+            entry("z", 26)
         );
     
     public static void main(String[] args)
     {
         String find = "x";
-        String[] arr = {"a", "b", "c", "x", "y"};
+        String[] array = {"a", "b", "c", "x", "y"};
         
         String test = "catalytic";
-        String[] array = {"cat", "catastrophe", "cattle", "catz"};
+        String[] arr = {"cat", "catastrophe", "cattle", "catz"};
         
         int num = 1;
         int[] arguments = {1, 2, 3, 4, 7, 9};
         
-        int varPos = searchFunc.sortedArraySearch(arr, find, letToNumMap);
+        // throws an error the values of find and arr are not defined in letToNumMap
+        int varPos = searchFunc.sortedArraySearch(array, find, letToNumMap);
         System.out.println("The variable 'find' is position " + varPos + " of our array.");
         
-        int stringPos = searchFunc.sortedArraySearch(array, test);
+        int stringPos = searchFunc.sortedArraySearch(arr, test);
         System.out.println("The string 'test' is position " + stringPos + " of our array.");
         
         int numPos = searchFunc.sortedArraySearch(arguments, num);

--- a/searchFunc.java
+++ b/searchFunc.java
@@ -3,7 +3,7 @@ import java.util.ArrayList;
 
 public class searchFunc
 {
-    public static int sortedArraySearch(String[] array, String target, Map<String, String> map)
+    public static int sortedArraySearch(String[] array, String target, Map<String, Integer> map)
     {
         int current = (array.length - 1) / 2;
         int modifier = current / 2;
@@ -11,7 +11,7 @@ public class searchFunc
         
         while (!target.equals(array[current]))
         {
-            boolean overshot = Integer.parseInt(map.get(array[current])) > Integer.parseInt(map.get(target));
+            boolean overshot = map.get(array[current]) > map.get(target);
             if (overshot)
             {
                 current -= modifier;


### PR DESCRIPTION
Updated map generics in both searcFunc and findX to use Integer instead of String for the value type in key-value pairs. This avoids using Integer.parseInt in searchFunc to map values into integers, removing unnecessary overhead.